### PR TITLE
Cleaned up build and added gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log*
+src/public/bundle.js

--- a/poc/POC.html
+++ b/poc/POC.html
@@ -1,14 +1,9 @@
 <html>
-
     <head>
         <title>iREEEc</title>
         <link rel="stylesheet" type="text/css" href="POC.css">
     </head>
     <body>
-
-
-
-
         <div id="logo">iREEEc</div>
 
         <div id="left">
@@ -24,8 +19,6 @@
             </div>
         </div>
 
-
-
         <div id="right">
             <div class="bar" id="chatBar">
                 <ul>
@@ -38,16 +31,11 @@
                 </ul>
             </div>
 
-            <div id="mainConsole">
-            </div>
+            <div id="mainConsole"></div>
 
-            <div id="consoleInput">
-            </div>
+            <div id="consoleInput"></div>
 
-            <div class="bigGreenButton">
-                Send
-            </div>
+            <div class="bigGreenButton">Send</div>
         </div>
-
     </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ var config = {
       {
         test : /\.jsx?/,
         include : APP_DIR,
-        loader : 'babel'
+        loader : 'babel-loader'
       }
     ]
   }


### PR DESCRIPTION
The configuration files were obsolete and using unsupported syntax for the babel-loader. The config files were also targeting a file that did not yet exist. Finally, there was no .gitignore for the project, so running `npm install` or `npm run build` created unstaged changes.